### PR TITLE
Add `x.com` to allowed embed domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ hexo.extend.tag.register('twitter', function(args, content){
 	var postId     = "";
 	var userId     = "";
 	var returnHTML = "";
+	var regexp = /https:\/\/(?:twitter|x)\.com\/([a-zA-Z0-9_]+)\/status\/([0-9]+)/;
 
-  	if(args[0] && args[0].match(/https\:\/\/twitter\.com\/[a-zA-Z0-9_]+\/status\/[0-9]+/)){
+  	if(args[0] && args[0].match(regexp)){
 
-	  	var matchURL = args[0].match(/https\:\/\/twitter\.com\/([a-zA-Z0-9_]+)\/status\/([0-9]+)/);
+	  	var matchURL = args[0].match(regexp);
 	  	postId = matchURL[2];
 	  	userId = matchURL[1];
 


### PR DESCRIPTION
This pull request adds x.com to the list of allowed embed domains. This change enables embedding content from x.com within the hexo-tag-twitter plugin.

## Summary of changes:

* Updated the list of allowed embed domains to include x.com.

Please review the changes and let me know if there are any issues. Thank you!